### PR TITLE
Add -Scope parameter to Get-ADTWinGetPackage

### DIFF
--- a/docs/Get-ADTWinGetPackage.mdx
+++ b/docs/Get-ADTWinGetPackage.mdx
@@ -13,7 +13,7 @@ Lists installed packages.
 
 ```powershell
 Get-ADTWinGetPackage [[-Query] <String>] [-MatchOption <String>] [-Command <String>] [-Count <UInt32>]
- [-Id <String>] [-Moniker <String>] [-Name <String>] [-Source <String>] [-Tag <String>] [<CommonParameters>]
+ [-Id <String>] [-Moniker <String>] [-Name <String>] [-Scope <String>] [-Source <String>] [-Tag <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -48,6 +48,15 @@ Get-ADTWinGetPackage -Name "PowerShell"
 
 This example shows how to get installed packages that match a name value.
 The command does a substring comparison of the provided name with installed package names.
+
+### EXAMPLE 4
+
+```powershell
+Get-ADTWinGetPackage -Scope System
+```
+
+This example shows how to list all packages installed in the machine scope.
+This is useful when running in the SYSTEM context.
 
 ## PARAMETERS
 
@@ -156,6 +165,24 @@ Specify the name of the package to list.
 Type: String
 Parameter Sets: (All)
 Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Scope
+
+Specify WinGet package installer scope.
+Use this parameter to list packages installed in the machine scope when running in the SYSTEM context.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Any, User, System, UserOrUnknown, SystemOrUnknown
 
 Required: False
 Position: Named

--- a/docs/test-plan-scope-parameter.md
+++ b/docs/test-plan-scope-parameter.md
@@ -1,0 +1,123 @@
+# Test Plan: Validate -Scope Parameter for Get-ADTWinGetPackage
+
+## Prerequisites
+
+- 1Password (`AgileBits.1Password`) must be installed in **machine scope** on the test system
+- PSAppDeployToolkit v4.0.6+ must be installed
+- WinGet CLI must be available
+
+---
+
+## Step 1: Import the Modified Module for Testing
+
+### Option A: Import Directly from Source (Recommended for Development)
+
+Open an **elevated PowerShell** session and run:
+
+```powershell
+# Remove any previously loaded version of the module
+Remove-Module PSAppDeployToolkit.WinGet -Force -ErrorAction SilentlyContinue
+
+# Import PSAppDeployToolkit first (required dependency)
+Import-Module PSAppDeployToolkit -MinimumVersion 4.1.7
+
+# Import the modified module directly from source
+Import-Module "N:\Tools\PSAppDeployToolkit.WinGet\src\PSAppDeployToolkit.WinGet\PSAppDeployToolkit.WinGet.psd1" -Force
+```
+
+### Option B: Verify Import and New Parameter
+
+After importing, verify the `-Scope` parameter is available:
+
+```powershell
+# Check that the Scope parameter exists
+(Get-Command Get-ADTWinGetPackage).Parameters['Scope']
+
+# View parameter details
+Get-Help Get-ADTWinGetPackage -Parameter Scope
+```
+
+**Expected Output:** Shows the `Scope` parameter with valid values: `Any`, `User`, `System`, `UserOrUnknown`, `SystemOrUnknown`
+
+### Option C: Quick Verification Script
+
+```powershell
+# One-liner to verify everything is working
+Remove-Module PSAppDeployToolkit.WinGet -Force -ErrorAction SilentlyContinue
+Import-Module PSAppDeployToolkit -MinimumVersion 4.0.6
+Import-Module "N:\Tools\PSAppDeployToolkit.WinGet\src\PSAppDeployToolkit.WinGet\PSAppDeployToolkit.WinGet.psd1" -Force
+(Get-Command Get-ADTWinGetPackage).Parameters.Keys -contains 'Scope'  # Should return True
+```
+
+---
+
+## Test Cases
+
+### Test 1: Verify Package Listed with `-Scope System`
+
+Run in an elevated PowerShell session or SYSTEM context:
+
+```powershell
+Get-ADTWinGetPackage -Id "AgileBits.1Password" -Scope System
+```
+
+**Expected Result:** Returns the 1Password package with its Name, Id, Version, and Source properties.
+
+### Test 2: Verify Package NOT Listed with `-Scope User` (when installed machine-wide)
+
+```powershell
+Get-ADTWinGetPackage -Id "AgileBits.1Password" -Scope User
+```
+
+**Expected Result:** Returns nothing (or different results if user also has a per-user installation).
+
+### Test 3: Verify `-Scope Any` Returns All Installations
+
+```powershell
+Get-ADTWinGetPackage -Id "AgileBits.1Password" -Scope Any
+```
+
+**Expected Result:** Returns all installations regardless of scope.
+
+### Test 4: List All Machine-Scoped Packages
+
+```powershell
+Get-ADTWinGetPackage -Scope System
+```
+
+**Expected Result:** Returns all packages installed in machine scope.
+
+### Test 5: Validate WinGet CLI Argument Passthrough
+
+Enable verbose/debug logging and verify the command generates:
+
+```
+winget list --id AgileBits.1Password --scope machine --exact --accept-source-agreements
+```
+
+### Test 6: Test in SYSTEM Context (Critical Use Case)
+
+Use `PsExec -s` or a SYSTEM-level deployment tool to run:
+
+```powershell
+Get-ADTWinGetPackage -Id "AgileBits.1Password" -Scope System
+```
+
+**Expected Result:** Successfully lists the package when running as SYSTEM.
+
+### Test 7: Combine with Other Parameters
+
+```powershell
+Get-ADTWinGetPackage -Name "1Password" -Scope System -MatchOption EqualsCaseInsensitive
+```
+
+**Expected Result:** Filters work correctly in combination with scope.
+
+## Validation Checklist
+
+- [ ] `-Scope System` returns machine-scoped packages
+- [ ] `-Scope User` returns user-scoped packages only
+- [ ] `-Scope Any` returns all packages
+- [ ] Works correctly in SYSTEM context
+- [ ] No errors when scope parameter is omitted (backward compatibility)
+- [ ] Documentation matches implementation

--- a/src/PSAppDeployToolkit.WinGet/Private/Invoke-ADTWinGetQueryOperation.ps1
+++ b/src/PSAppDeployToolkit.WinGet/Private/Invoke-ADTWinGetQueryOperation.ps1
@@ -42,10 +42,6 @@ function Invoke-ADTWinGetQueryOperation
         [System.String]$Name,
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet('Any', 'User', 'System', 'UserOrUnknown', 'SystemOrUnknown')]
-        [System.String]$Scope,
-
-        [Parameter(Mandatory = $false)]
         [ValidateScript({
                 try
                 {
@@ -60,7 +56,11 @@ function Invoke-ADTWinGetQueryOperation
 
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
-        [System.String]$Tag
+        [System.String]$Tag,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Any', 'User', 'System', 'UserOrUnknown', 'SystemOrUnknown')]
+        [System.String]$Scope
     )
 
     # Confirm WinGet is good to go.
@@ -84,6 +84,7 @@ function Invoke-ADTWinGetQueryOperation
 
     # Translate Scope parameter values to WinGet CLI equivalents.
     # PowerShell uses 'System'/'User' but WinGet CLI expects 'machine'/'user'.
+    # This must happen BEFORE Convert-ADTFunctionParamsToArgArray is called.
     if ($PSBoundParameters.ContainsKey('Scope'))
     {
         $PSBoundParameters['Scope'] = switch ($PSBoundParameters['Scope'])
@@ -123,10 +124,10 @@ function Invoke-ADTWinGetQueryOperation
         if ($Action -eq 'search')
         {
             $naerParams = @{
-                Exception = [System.IO.InvalidDataException]::new("No package found matching input criteria.")
-                Category = [System.Management.Automation.ErrorCategory]::InvalidResult
-                ErrorId = "WinGetPackageNotFoundError"
-                TargetObject = $PSBoundParameters
+                Exception         = [System.IO.InvalidDataException]::new("No package found matching input criteria.")
+                Category          = [System.Management.Automation.ErrorCategory]::InvalidResult
+                ErrorId           = "WinGetPackageNotFoundError"
+                TargetObject      = $PSBoundParameters
                 RecommendedAction = "Please review the specified input, then try again."
             }
             $PSCmdlet.ThrowTerminatingError((New-ADTErrorRecord @naerParams))

--- a/src/PSAppDeployToolkit.WinGet/Private/Invoke-ADTWinGetQueryOperation.ps1
+++ b/src/PSAppDeployToolkit.WinGet/Private/Invoke-ADTWinGetQueryOperation.ps1
@@ -1,4 +1,4 @@
-﻿#-----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 #
 # MARK: Invoke-ADTWinGetQueryOperation
 #
@@ -42,6 +42,10 @@ function Invoke-ADTWinGetQueryOperation
         [System.String]$Name,
 
         [Parameter(Mandatory = $false)]
+        [ValidateSet('Any', 'User', 'System', 'UserOrUnknown', 'SystemOrUnknown')]
+        [System.String]$Scope,
+
+        [Parameter(Mandatory = $false)]
         [ValidateScript({
                 try
                 {
@@ -76,6 +80,26 @@ function Invoke-ADTWinGetQueryOperation
     if ($PSBoundParameters.ContainsKey('Id'))
     {
         $MatchOption = 'Equals'
+    }
+
+    # Translate Scope parameter values to WinGet CLI equivalents.
+    # PowerShell uses 'System'/'User' but WinGet CLI expects 'machine'/'user'.
+    if ($PSBoundParameters.ContainsKey('Scope'))
+    {
+        $PSBoundParameters['Scope'] = switch ($PSBoundParameters['Scope'])
+        {
+            'System' { 'machine'; break }
+            'SystemOrUnknown' { 'machine'; break }
+            'User' { 'user'; break }
+            'UserOrUnknown' { 'user'; break }
+            'Any' { $null; break }
+            default { $PSBoundParameters['Scope'] }
+        }
+        # Remove Scope if it was set to $null (e.g., 'Any' means no scope filter).
+        if ($null -eq $PSBoundParameters['Scope'])
+        {
+            $null = $PSBoundParameters.Remove('Scope')
+        }
     }
 
     # Set up arguments array for WinGet.

--- a/src/PSAppDeployToolkit.WinGet/Public/Get-ADTWinGetPackage.ps1
+++ b/src/PSAppDeployToolkit.WinGet/Public/Get-ADTWinGetPackage.ps1
@@ -1,4 +1,4 @@
-﻿#-----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 #
 # MARK: Get-ADTWinGetPackage
 #
@@ -34,6 +34,9 @@ function Get-ADTWinGetPackage
     .PARAMETER Name
         Specify the name of the package to list.
 
+    .PARAMETER Scope
+        Specify WinGet package installer scope. Use this parameter to list packages installed in the machine scope when running in the SYSTEM context.
+
     .PARAMETER Source
         Specify the name of the WinGet source of the package.
 
@@ -64,6 +67,11 @@ function Get-ADTWinGetPackage
         Get-ADTWinGetPackage -Name "PowerShell"
 
         This example shows how to get installed packages that match a name value. The command does a substring comparison of the provided name with installed package names.
+
+    .EXAMPLE
+        Get-ADTWinGetPackage -Scope System
+
+        This example shows how to list all packages installed in the machine scope. This is useful when running in the SYSTEM context.
 
     .LINK
         https://github.com/mjr4077au/PSAppDeployToolkit.WinGet
@@ -99,6 +107,10 @@ function Get-ADTWinGetPackage
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [System.String]$Name,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Any', 'User', 'System', 'UserOrUnknown', 'SystemOrUnknown')]
+        [System.String]$Scope,
 
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]


### PR DESCRIPTION
# Pull Request

## Issue

Get-ADTWinGetPackage does not return system-wide install when running under SYSTEM context.

## Description

Description of changes:

Adds -Scope parameter to Get-ADTWinGetPackage to filter installed packages by installation scope (user vs machine).


### Changes

- **`Get-ADTWinGetPackage.ps1`**: Added `-Scope` parameter with valid values: `Any`, `User`, `System`, `UserOrUnknown`, `SystemOrUnknown`
- **`Invoke-ADTWinGetQueryOperation.ps1`**: 
  - Added `-Scope` parameter to accept scope from public function
  - Added translation logic to convert PowerShell-style values to WinGet CLI equivalents (`System` → `machine`, `User` → `user`)
  - Translation occurs before `Convert-ADTFunctionParamsToArgArray` is called to ensure correct CLI arguments
- **`Get-ADTWinGetPackage.mdx`**: Updated documentation with new parameter and example

### Scope Value Mapping

| PowerShell Value | WinGet CLI |
|------------------|------------|
| `System` / `SystemOrUnknown` | `--scope machine` |
| `User` / `UserOrUnknown` | `--scope user` |
| `Any` | *(no --scope flag)* |

### Use Case

This enables querying machine-scoped packages when running in the SYSTEM context, which is essential for deployment scenarios where the user registry hive is not available.

```powershell
# List all machine-scoped packages
Get-ADTWinGetPackage -Scope System

# Check if a specific package is installed machine-wide
Get-ADTWinGetPackage -Id "AgileBits.1Password" -Scope System
```



