### PR TITLE
Also fail on Pester block/container failures (not just failed tests)

### DIFF
--- a/src/PSAppDeployToolkit.WinGet.build.ps1
+++ b/src/PSAppDeployToolkit.WinGet.build.ps1
@@ -255,7 +255,7 @@ Add-BuildTask Test {
         }
 
         # Publish results.
-        Assert-Build (($numberFails = $testResults.FailedCount) -eq 0) ('Failed "{0}" unit tests.' -f $numberFails)
+        Assert-Build (($numberFails = ($testResults.FailedCount + $testResults.FailedBlocksCount + $testResults.FailedContainersCount)) -eq 0) ('Failed "{0}" unit tests.' -f $numberFails)
         Write-Build Gray ('      ...CODE COVERAGE - CommandsExecutedCount: {0}' -f $testResults.CodeCoverage.CommandsExecutedCount)
         Write-Build Gray ('      ...CODE COVERAGE - CommandsAnalyzedCount: {0}' -f $testResults.CodeCoverage.CommandsAnalyzedCount)
         if ($testResults.CodeCoverage.CommandsExecutedCount -ne 0)
@@ -561,7 +561,7 @@ Add-BuildTask IntegrationTest {
         }
 
         # Report on failures.
-        $numberFails = $testResults.FailedCount
+        $numberFails = ($testResults.FailedCount + $testResults.FailedBlocksCount + $testResults.FailedContainersCount)
         Assert-Build($numberFails -eq 0) ('Failed "{0}" unit tests.' -f $numberFails)
         Write-Build Green '      ...Pester Integration Tests Complete!'
     }


### PR DESCRIPTION
> ⚠️ This PR was generated by an AI agent (GitHub Copilot CLI). Please review accordingly.

I've been seeing this commonly across Pester 5 build scripts and I'm fixing it where it looks like it could hide real failures.

In Pester 5 a run reports three independent failure counts:

- `FailedCount` — failed tests (`It`)
- `FailedBlocksCount` — failed `BeforeAll` / `AfterAll`
- `FailedContainersCount` — files that error during discovery / fail to load

Gating on only `FailedCount` means a `BeforeAll` that throws, or a test file that fails to load, leaves `FailedCount = 0` and the build passes green despite real failures. Pester itself derives the overall pass/fail from the sum of all three.

This change includes all three counts in the gate. Display/log messages are left unchanged.
